### PR TITLE
Unpack when folder name doesn't match component

### DIFF
--- a/7/rootfs/libcomponent.sh
+++ b/7/rootfs/libcomponent.sh
@@ -59,6 +59,6 @@ component_unpack() {
         echo "Verifying package integrity"
         echo "$package_sha256  ${base_name}.tar.gz" | sha256sum --check -
     fi
-    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/${name}"
+    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/"
     rm "${base_name}.tar.gz"
 }


### PR DESCRIPTION
`component_unpack` was looking for files under `${base_name}/files/${name}`, but there are some containers that don't follow the same format.

Syncs with the other base images:
https://github.com/bitnami/oraclelinux-extras-base/pull/11
https://github.com/bitnami/minideb-extras-base/pull/248