### PR TITLE
Fix lib fsFix 'libfs.sh' by loading 'liblog.sh' from the right path

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 ENV IMAGE_OS=centos-7
 
-ENV BITNAMI_IMAGE_VERSION=7-r33
+ENV BITNAMI_IMAGE_VERSION=7-r34
 
 COPY rootfs /
 

--- a/7/rootfs/libfs.sh
+++ b/7/rootfs/libfs.sh
@@ -3,7 +3,7 @@
 # Library for file system actions
 
 # Load Generic Libraries
-. ./liblog.sh
+. /liblog.sh
 
 # Functions
 


### PR DESCRIPTION
This PR fixes 'libfs.sh' by loading 'liblog.sh' from the right path.